### PR TITLE
Add iconic taxa filtering for category-based species selection

### DIFF
--- a/inaturalist_client.py
+++ b/inaturalist_client.py
@@ -45,17 +45,20 @@ class INaturalistClient:
         place_id: int,
         top_n: int,
         selected_months: List[int] | None = None,
+        selected_iconic_taxa: List[str] | None = None,
     ) -> List[Species]:
         """Return a list of top‑N species for the given place.
 
         Filters to research‑grade observations at species level or below.
-        Optionally filters by months.
+        Optionally filters by months and iconic taxa.
 
         Args:
             place_id: iNaturalist place ID
             top_n: Number of top species to return
             selected_months: List of month numbers (1-12) to filter by,
                 or None for all months
+            selected_iconic_taxa: List of iconic taxa names to filter by,
+                or None for all taxa
         """
         try:
             # Use species_counts endpoint for proper geographic aggregation
@@ -72,6 +75,10 @@ class INaturalistClient:
             # Add month filtering if specified
             if selected_months:
                 params["month"] = ",".join(map(str, selected_months))
+            
+            # Add iconic taxa filtering if specified
+            if selected_iconic_taxa:
+                params["iconic_taxa"] = selected_iconic_taxa
 
             resp = requests.get(
                 "https://api.inaturalist.org/v1/observations/species_counts",

--- a/ui.py
+++ b/ui.py
@@ -34,8 +34,34 @@ class BingoApp:
 
     def _render_form(self) -> dict | None:
         """Render the input form and return form data if submitted."""
-        # Time filtering options (outside form for dynamic updates)
-        st.subheader("Time Filtering")
+        # Filtering options (outside form for dynamic updates)
+        st.subheader("Filtering Options")
+        
+        # Category filtering
+        iconic_taxa_options = {
+            "Aves": "Birds",
+            "Mammalia": "Mammals", 
+            "Plantae": "Plants",
+            "Insecta": "Insects",
+            "Reptilia": "Reptiles",
+            "Amphibia": "Amphibians",
+            "Actinopterygii": "Ray-finned Fish",
+            "Mollusca": "Mollusks",
+            "Arachnida": "Spiders & Arachnids",
+            "Fungi": "Fungi"
+        }
+        
+        iconic_taxa_enabled = st.checkbox("Filter by category", value=False)
+        selected_iconic_taxa = []
+        if iconic_taxa_enabled:
+            selected_iconic_taxa = st.multiselect(
+                "Select categories to include",
+                options=list(iconic_taxa_options.keys()),
+                format_func=lambda x: iconic_taxa_options[x],
+                help="Species will be filtered to only include these categories",
+            )
+        
+        # Time filtering
         time_filter_enabled = st.checkbox("Filter by months", value=False)
         selected_months = []
         if time_filter_enabled:
@@ -105,6 +131,9 @@ class BingoApp:
                 "selected_months": (
                     selected_months if time_filter_enabled else None
                 ),
+                "selected_iconic_taxa": (
+                    selected_iconic_taxa if iconic_taxa_enabled else None
+                ),
             }
 
         return None
@@ -124,7 +153,7 @@ class BingoApp:
 
         # Fetch species data
         species_pool = self._fetch_species_data(
-            place_id, form_data["top_n"], form_data["selected_months"]
+            place_id, form_data["top_n"], form_data["selected_months"], form_data["selected_iconic_taxa"]
         )
         if not species_pool:
             return
@@ -164,12 +193,13 @@ class BingoApp:
         place_id: int,
         top_n: int,
         selected_months: List[int] | None,
+        selected_iconic_taxa: List[str] | None,
     ) -> List[Any] | None:
         """Fetch species data from iNaturalist."""
         with st.spinner("Fetching species list from iNaturalist…"):
             try:
                 return self.client.fetch_top_species(
-                    place_id, top_n, selected_months
+                    place_id, top_n, selected_months, selected_iconic_taxa
                 )
             except Exception as e:
                 st.error(f"Error fetching species data: {e}")


### PR DESCRIPTION
## Summary
- Add category filtering UI with 10 iconic taxa options (Birds, Mammals, Plants, etc.)
- Integrate iNaturalist API's `iconic_taxa` parameter for backend filtering
- Enable users to create specialized bingo cards focused on specific taxonomic groups

## Test plan
- [ ] Verify category filtering UI displays correctly
- [ ] Test filtering with single category (e.g., Birds only)  
- [ ] Test filtering with multiple categories
- [ ] Confirm existing month filtering still works
- [ ] Generate PDF with filtered results to verify correct species inclusion

🤖 Generated with [Claude Code](https://claude.ai/code)